### PR TITLE
fix: if the build step fails release should halt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,9 +81,9 @@ jobs:
       - run: npm test
 
   release:
-    needs: test
-    # only run if opt-in during workflow_dispatch, and run if tests are skipped using the toggle, but not if they have failed
-    if: always() && github.event.inputs.release == 'true' && needs.test.result != 'failure' && needs.test.result != 'cancelled'
+    needs: [build, test]
+    # only run if opt-in during workflow_dispatch
+    if: always() && github.event.inputs.release == 'true' && needs.build.result != 'failure' && needs.test.result != 'failure' && needs.test.result != 'cancelled'
     runs-on: ubuntu-latest
     name: Semantic release
     steps:

--- a/assets/inject/semver-workflow/.github/workflows/main.yml
+++ b/assets/inject/semver-workflow/.github/workflows/main.yml
@@ -91,8 +91,9 @@ jobs:
 
   release:
     needs: test
-    # only run if opt-in during workflow_dispatch, and run if tests are skipped using the toggle, but not if they have failed
-    if: always() && github.event.inputs.release == 'true' && needs.test.result != 'failure' && needs.test.result != 'cancelled'
+    needs: [build, test]
+    # only run if opt-in during workflow_dispatch
+    if: always() && github.event.inputs.release == 'true' && needs.build.result != 'failure' && needs.test.result != 'failure' && needs.test.result != 'cancelled'
     runs-on: ubuntu-latest
     name: Semantic release
     steps:


### PR DESCRIPTION
As it turns out the build step must also be explicitly checked to see if it had a failure when using `always()`, as seen in `next-sanity` it otherwise will proceed and you'll end up with git commit + git tags but nothing published to npm 😭  https://github.com/sanity-io/next-sanity/actions/runs/3394197261/jobs/5642475373