### PR TITLE
ci: workflow nanme based on inputs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,14 @@
 ---
 name: CI & Release
 
-# Workflow name in the actions list, falls back to default naming (PR, commit depending) when expression evaluates to empty string
-run-name: "${{inputs.release && 'Publish to NPM' || github.event_name == 'workflow_dispatch' && 'Manual run: Build & Test' }} || ''"
+# Workflow name based on selected inputs. Fallback to default naming when expression evaluates to empty string
+run-name: >
+  ${{
+    inputs.release && inputs.test && 'Build & Test -> Publish to NPM' ||
+    inputs.release && !inputs.test && 'Build & Skip Tests -> Publish to NPM' ||
+    github.event_name == 'workflow_dispatch' && inputs.test && 'Manual run: Build & Test' ||
+    github.event_name == 'workflow_dispatch' && !inputs.test && 'Manual run: Build only' ||
+  }}
 
 on:
   # Build on pushes branches that have a PR (including drafts)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 ---
 name: CI & Release
 
-# Workflow name in the actions list, falls back to commit message when expression evaluates to empty string
+# Workflow name in the actions list, falls back to default naming (PR, commit depending) when expression evaluates to empty string
 run-name: "${{inputs.release && 'Publish to NPM' || github.event_name == 'workflow_dispatch' && 'Manual run: Build & Test' }} || ''"
 
 on:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 ---
 name: CI & Release
 
-# Workflow name based on selected inputs. Fallback to default naming when expression evaluates to empty string
+# Workflow name based on selected inputs. Fallback to default Github naming when expression evaluates to empty string
 run-name: >-
   ${{
     inputs.release && inputs.test && 'Build & Test -> Publish to NPM' ||

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,10 @@ name: CI & Release
 # Workflow name based on selected inputs. Fallback to default Github naming when expression evaluates to empty string
 run-name: >-
   ${{
-    inputs.release && inputs.test && 'Build & Test -> Publish to NPM' ||
-    inputs.release && !inputs.test && 'Build & Skip Tests -> Publish to NPM' ||
-    github.event_name == 'workflow_dispatch' && inputs.test && 'Manual run: Build & Test' ||
-    github.event_name == 'workflow_dispatch' && !inputs.test && 'Manual run: Build only' ||
+    inputs.release && inputs.test && 'Build ➤ Test ➤ Publish to NPM' ||
+    inputs.release && !inputs.test && 'Build ➤ Skip Tests ➤ Publish to NPM' ||
+    github.event_name == 'workflow_dispatch' && inputs.test && 'Build ➤ Test' ||
+    github.event_name == 'workflow_dispatch' && !inputs.test && 'Build ➤ Skip Tests' ||
     ''
   }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 name: CI & Release
 
 # Workflow name in the actions list, falls back to commit message when expression evaluates to empty string
-run-name: "${{inputs.release && 'Publish to NPM' || github.event_name == 'workflow_dispatch' && 'Manual run: Build & Test' }}"
+run-name: "${{inputs.release && 'Publish to NPM' || github.event_name == 'workflow_dispatch' && 'Manual run: Build & Test' }} || ''"
 
 on:
   # Build on pushes branches that have a PR (including drafts)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,13 @@
 name: CI & Release
 
 # Workflow name based on selected inputs. Fallback to default naming when expression evaluates to empty string
-run-name: >
+run-name: >-
   ${{
     inputs.release && inputs.test && 'Build & Test -> Publish to NPM' ||
     inputs.release && !inputs.test && 'Build & Skip Tests -> Publish to NPM' ||
     github.event_name == 'workflow_dispatch' && inputs.test && 'Manual run: Build & Test' ||
     github.event_name == 'workflow_dispatch' && !inputs.test && 'Manual run: Build only' ||
+
   }}
 
 on:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ run-name: >-
     inputs.release && !inputs.test && 'Build & Skip Tests -> Publish to NPM' ||
     github.event_name == 'workflow_dispatch' && inputs.test && 'Manual run: Build & Test' ||
     github.event_name == 'workflow_dispatch' && !inputs.test && 'Manual run: Build only' ||
-
+    ''
   }}
 
 on:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 ---
 name: CI & Release
 
+# Workflow name in the actions list, falls back to commit message when expression evaluates to empty string
+run-name: "${{inputs.release && 'Publish to NPM' || github.event_name == 'workflow_dispatch' && 'Manual run: Build & Test' }}"
+
 on:
   # Build on pushes branches that have a PR (including drafts)
   pull_request:

--- a/assets/inject/semver-workflow/.github/workflows/main.yml
+++ b/assets/inject/semver-workflow/.github/workflows/main.yml
@@ -1,6 +1,16 @@
 ---
 name: CI & Release
 
+# Workflow name based on selected inputs. Fallback to default Github naming when expression evaluates to empty string
+run-name: >-
+  ${{
+    inputs.release && inputs.test && 'Build ➤ Test ➤ Publish to NPM' ||
+    inputs.release && !inputs.test && 'Build ➤ Skip Tests ➤ Publish to NPM' ||
+    github.event_name == 'workflow_dispatch' && inputs.test && 'Build ➤ Test' ||
+    github.event_name == 'workflow_dispatch' && !inputs.test && 'Build ➤ Skip Tests' ||
+    ''
+  }}
+
 on:
   # Build on pushes branches that have a PR (including drafts)
   pull_request:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/835514/200084273-2aba2943-6faf-48ba-baaa-13d055e2e427.png)

I think it is nice to see at-a-glance if tests where run, if release was actioned ect.

Ideally I would like to change the name of the run after we have a version, but have not found an api for that.