### PR TITLE
Change guidance to use yarn install

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ This will publish the plugin to a local [yalc](https://github.com/wclr/yalc) reg
 In another shell, in your test Sanity Studio directory, run:
 
 ```sh
-npx yalc add <your-plugin-package> && npx yalc add <your-plugin-package> --link && npm install
+npx yalc add <your-plugin-package> && npx yalc add <your-plugin-package> --link && yarn install
 ```
 
 You can now change your plugin code, which will:


### PR DESCRIPTION
When following the development instructions for testing a package with yalc, `npm install` will fail with a message like the following:

```bash
$ npm install
npm ERR! code EUNSUPPORTEDPROTOCOL
npm ERR! Unsupported URL Type "link:": link:.yalc/sanity-plugin-table

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/davidlucia/.npm/_logs/2022-11-09T14_07_27_183Z-debug-0.log
```

This is because npm does not support `link:` syntax in packages. I tested this on Node 16x and 18x. `yarn install` does work

Signed-off-by: Dave Lucia <davelucianyc@gmail.com>