### PR TITLE
fix: support how renovatebot generate lockfiles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           cache: npm
           node-version: ${{ matrix.node }}
-      - run: npm ci
+      - run: npm i
       - run: npm test
 
   release:

--- a/assets/inject/semver-workflow/.github/workflows/main.yml
+++ b/assets/inject/semver-workflow/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           cache: npm
           node-version: ${{ matrix.node }}
-      - run: npm ci
+      - run: npm i
       - run: npm test --if-present
 
   release:

--- a/docs/semver-workflow.md
+++ b/docs/semver-workflow.md
@@ -7,7 +7,8 @@ semantic-release driven workflow on Github for Sanity v3 plugins.
 
 ### 1. Install new dependencies
 
-Run 
+Run
+
 ```bash
 npm install
 ```
@@ -33,13 +34,14 @@ on:
     branches: [main, v3]
 ```
 
-### 4. Check secrets 
+### 4. Check secrets
+
 Ensure that your repo or Github org has set the secrets used by the workflow.
 
 `secrets.GITHUB_TOKEN` should always be available by default, but
-`secrets.NPM_PUBLISH_TOKEN` is not. 
+`secrets.NPM_PUBLISH_TOKEN` is not.
 
-Secrets can be set using `Settings -> Secrets -> Actions -> "New reposiotry secret"`
+Secrets can be set using `Settings -> Secrets -> Actions -> "New repository secret"`
 on Github for a repository.
 
 ### 5. Update .releaserc.json
@@ -88,6 +90,3 @@ semantic-release driven workflow on Github.
 - Adds husky and related files and dependencies to do pre-commit checks
 - Adds semantic-release and preset dependencies to automate npm & Github releases
 - Updates README.md with some standard texts
-
-
-


### PR DESCRIPTION
Renovatebot is now defaulting to [`lockfileVersion`](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json#lockfileversion) set to `3`. Our CI setup is using `npm ci` everywhere, including for tests on node v14. Which doesn't work. As node v14 is using an older version of `npm` that does not support the new lockfile format.

You can see this in the [PR](https://github.com/sanity-io/plugin-kit/pull/46) it made for [recreating the lockfile](https://github.com/sanity-io/plugin-kit/actions/runs/3471159500/jobs/5800315004), which our preset asks renovate to do monthly.

By changing it to `npm i` the npm client that might not support the latest lockfile version will fallback to using `package.json` as its truth and ignore the lockfile. Which is fine. The lockfile is the most important for linting, building and most of all the `semantic-release` process as we never want new dependencies to be pulled in in those build steps. The lockfile is the truth.
However when running testing suites on different node versions it's completely fine to ignore the lockfile in some cases, it just means it'll take a little longer to install.

I've tested the changes proposed in this PR on [this repo](https://github.com/sanity-io/preview-kit), see the relevant [PR](https://github.com/sanity-io/preview-kit/pull/11). And the [log output](https://github.com/sanity-io/preview-kit/actions/runs/3470618824/jobs/5799060578) of what happens when and older npm encounters a lockfile version it doesn't know how to deal with:
```bash
Run actions/setup-node@8c91899e586c5b171469028077307d293428b516
Environment details
  node: v14.20.1
  
  npm: 6.14.17
  
  yarn: 1.22.19

------

Run npm i
npm WARN read-shrinkwrap This version of npm is compatible with lockfileVersion@1, but package-lock.json was generated for lockfileVersion@3. I'll try to do my best with it!
```