### PR TITLE
Patch: Lock @sanity/pkg-utils to stable version to enable smooth dx

### DIFF
--- a/src/configs/forced-package-versions.ts
+++ b/src/configs/forced-package-versions.ts
@@ -1,4 +1,6 @@
-export const forcedPackageVersions = {}
+export const forcedPackageVersions = {
+  '@sanity/pkg-utils': '5.1.0',
+}
 
 export const forcedDevPackageVersions = forcedPackageVersions
 
@@ -10,4 +12,5 @@ export const forcedPeerPackageVersions = {
   '@types/react-dom': '^18',
   sanity: '^3',
   'styled-components': '^5.2',
+  '@sanity/pkg-utils': '5.1.0',
 }

--- a/src/npm/resolveLatestVersions.ts
+++ b/src/npm/resolveLatestVersions.ts
@@ -4,6 +4,7 @@ import getLatestVersion from 'get-latest-version'
 // We may want to lock certain dependencies to specific versions
 const lockedDependencies: Record<string, string> = {
   'styled-components': '^5.2',
+  '@sanity/pkg-utils': '5.1.0',
 }
 
 export function resolveLatestVersions(packages: string[]) {


### PR DESCRIPTION
Opening this pull request after reproducing the behavior described in both sanity-io/plugins#1122  and sanity-io/plugins#1124. 

Filing this PR as more of an *idea* in an attempt to come up with answers for the issues mentioned above.

The proposed changes offer a temporary fix ( band-aid 🩹 ) for an issue I've been experiencing for a little while now. 

It seems important for me to acknowledge that my experience may be part of a small percentage of the over dx for this package.  Because of this these changes could very likely cause regressions (especially considering the locking of the devDependency `@sanity/pkg-utils`. 

All this being said—consider these changes as an *idea* for how to resolve this if you're also running into this barrier.

For more context on the behavior described in the open issues mentioned above:

## Context

Node installed on Mac Metal

**Node version**
```console
❯ node -v
v18.19.0
```

**Operating System**
```console
❯ sw_vers
ProductName:		macOS
ProductVersion:		14.4
BuildVersion:		23E214
```

**plugin-kit version**
```console
❯ npx @sanity/plugin-kit --version
3.1.10
```

When running `npx @sanity/plugin-kit init sanity-plugin-cool-plugin-name` and attempting to run `npm run link-watch` in the subsequently generated `sanity-plugin-cool-plugin-name` directory the following error is returned:

<details>

<summary>Expand for Error</summary>

```console
❯ pnpm link-watch

> sanity-plugin-cool-plugin-name@1.0.0 link-watch /Users/emmalevesque-schaefer/Code/sanity/plugins/sanity-plugin-cool-plugin-name
> plugin-kit link-watch

[info] Watching dist for changes to files with extensions: ts,js,png,svg,gif,jpeg,css

To test this package in Sanity Studio or another package, in a separate shell run:
cd /path/to/sanity/studio-or-package

Then, run one of the below commands, based on the package manager used in studio-or-package:

## yarn
yalc add --link sanity-plugin-cool-plugin-name && yarn install

## npm
npx yalc add sanity-plugin-cool-plugin-name && npx yalc link sanity-plugin-cool-plugin-name && npm install
sanity-plugin-cool-plugin-name@1.0.0 published in store.
[0]
[0] > sanity-plugin-cool-plugin-name@1.0.0 watch
[0] > pkg-utils watch --strict
[0]
[0] [error] the \`type\` field in \`./package.json\` must be either "module" or "commonjs")
[0] [error] exports["."]: the \`types\` condition shouldn't be used as dts files are generated in such a way that both CJS and ESM is supported
[0] [warning] exports["."]: the \`import\` property should come before the \`require\` property
[0] npm run watch exited with code 1
Error: Promise rejected with value: [
  {
    command: Command {
      close: [Subject],
      error: [Subject],
      stdout: [Subject],
      stderr: [Subject],
      timer: [Subject],
      killed: false,
      exited: true,
      index: 0,
      name: '',
      command: 'npm run watch',
      prefixColor: '',
      env: {},
      cwd: '',
      killProcess: [Function (anonymous)],
      spawn: [Function (anonymous)],
      spawnOpts: [Object],
      process: undefined,
      pid: 44263,
      stdin: [Socket]
    },
    index: 0,
    exitCode: 1,
    killed: false,
    timings: {
      startDate: 2024-03-28T02:18:30.151Z,
      endDate: 2024-03-28T02:18:31.314Z,
      durationSeconds: 1.163361833
    }
  }
]
    at process.<anonymous> (/Users/emmalevesque-schaefer/Code/sanity/plugins/sanity-plugin-cool-plugin-name/node_modules/.pnpm/hard-rejection@2.1.0/node_modules/hard-rejection/index.js:15:12)
    at process.emit (node:events:517:28)
    at emit (node:internal/process/promises:149:20)
    at processPromiseRejections (node:internal/process/promises:283:27)
    at process.processTicksAndRejections (node:internal/process/task_queues:96:32)
 ELIFECYCLE  Command failed with exit code 1.

```
 
  </details>

 ## Looking for a Fix

I first checked the @sanity/plugin-kit change log for any releases that seemed related to the errors I was seeing. Nothing jumped out at me so I returned to the initial output of the plugin generation and noticed:

```console
 WARN  Issues with peer dependencies found
.
└─┬ @sanity/pkg-utils 5.1.4
  └── ✕ unmet peer typescript@5.4.2: found 5.4.3
  ```
This being a warning I didn't think was the cause of the issue but it did encourage me to check @sanity/pkg-utils for related releases.

I came across this in the change log:

> [v5.1.1](https://github.com/sanity-io/pkg-utils/releases/tag/v5.1.1)
[5.1.1](https://github.com/sanity-io/pkg-utils/compare/v5.1.0...v5.1.1) (2024-03-20)
Bug Fixes
ensure no "Masquerading as ESM|CJS" dts errors (https://github.com/sanity-io/pkg-utils/pull/627) ([e54dc10](https://github.com/sanity-io/pkg-utils/commit/e54dc100686631bbf2fbae37515097c6785ca53d))

## Finding a Resolution

Testing to see if this would resolve the build error I pinned @sanity/pkg-utils to the version immediately before 5.1.1 e.g. 5.1.0. I did this by adding the following to my package.json

```ts
...
"resolutions": {
    "@sanity/pkg-utils": "5.1.0",
    },
...
```


Once this change was made I reinstalled my packages and attempted to build the plugin again and it worked 😎 

## That's it

That's how I can up with the proposed change here. Sorry if this was long-winded 😮‍💨